### PR TITLE
Add docker-nuke function

### DIFF
--- a/zsh-scripts/rc/50-aliases
+++ b/zsh-scripts/rc/50-aliases
@@ -72,6 +72,17 @@ function git-add-commit-push() {
         git add -A && git commit -m "$1" && git push
 }
 
+# Stop and remove all Docker containers
+function docker-nuke() {
+        local containers
+        containers=$(docker ps -aq)
+        if [[ -n "$containers" ]]; then
+                docker stop ${=containers} && docker rm ${=containers}
+        else
+                echo "No containers to remove"
+        fi
+}
+
 # Power grep with better output and case-insensitivity
 alias xgrep='egrep -Ri --line-number --before-context=3 --after-context=3 --color=always'
 


### PR DESCRIPTION
## Summary
- Add `docker-nuke` shell function that stops and removes all Docker containers in one command
- Uses zsh `${=var}` word splitting for correct multi-container handling
- Includes empty container list check with user-friendly message

## Test plan
- [ ] Run `docker-nuke` with running containers — all should be stopped and removed
- [ ] Run `docker-nuke` with no containers — should print "No containers to remove"